### PR TITLE
Enabled wider compatibility for .compat_load

### DIFF
--- a/ext/oj/parse.c
+++ b/ext/oj/parse.c
@@ -263,6 +263,10 @@ read_escaped_str(ParseInfo pi, const char *start) {
 		}
 		break;
 	    default:
+		if (CompatMode == pi->options.mode) {
+		    buf_append(&buf, *s);
+		    break;
+		}
 		pi->cur = s;
 		oj_set_error_at(pi, oj_parse_error_class, __FILE__, __LINE__, "invalid escaped character");
 		buf_cleanup(&buf);

--- a/test/test_compat.rb
+++ b/test/test_compat.rb
@@ -236,6 +236,12 @@ class CompatJuice < Minitest::Test
     assert_equal({"a\nb" => true, "c\td" => false}, obj)
   end
 
+  def test_invalid_escapes_handled
+    json = '{"subtext":"\"404er\” \w \k \3 \a"}'
+    obj = Oj.compat_load(json)
+    assert_equal({"subtext" => "\"404er” w k 3 a"}, obj)
+  end
+
   def test_hash_escaping
     json = Oj.to_json({'<>' => '<>'}, mode: :compat)
     assert_equal(json, '{"<>":"<>"}')


### PR DESCRIPTION
Greater parity with `JSON.parse` on ruby, where it will ignore `/` in case of an invalid escape character. Such as `\”` (curly double quote) will be parsed to just `”`

Tested with `./build_test.sh`

Related: https://github.com/Shopify/storefront-renderer/pull/5606